### PR TITLE
fix: move group check inside secureHandler to prevent blocking unauthenticated users

### DIFF
--- a/oidc.go
+++ b/oidc.go
@@ -216,16 +216,22 @@ func (svc *OIDC) SecureFunc(next http.HandlerFunc, allowedGroups ...string) http
 //
 // Current ID token get be obtained by [Token] from request.
 func (svc *OIDC) Secure(next http.Handler, allowedGroups ...string) http.Handler {
-	handler := svc.secureHandler(next)
-	if len(allowedGroups) == 0 {
-		return handler
+	if len(allowedGroups) > 0 {
+		next = svc.restrictGroups(next, allowedGroups)
 	}
+	return svc.secureHandler(next)
+}
+
+// restrictGroups wraps a handler with a group membership check.
+// The ID token must already be present in the request context
+// (i.e. this must be called after authentication has succeeded inside secureHandler).
+func (svc *OIDC) restrictGroups(next http.Handler, allowedGroups []string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if Belongs(r, allowedGroups...) {
-			handler.ServeHTTP(w, r)
+		if !Belongs(r, allowedGroups...) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		next.ServeHTTP(w, r)
 	})
 }
 

--- a/oidc.go
+++ b/oidc.go
@@ -97,6 +97,9 @@ type Config struct {
 	// For example, 5*time.Minute refreshes tokens 5 minutes before they expire.
 	// Default is 0 (only refresh when expired).
 	RefreshBefore time.Duration
+	// (optional) handler for 403 Forbidden responses when the user is authenticated
+	// but not in any of the allowed groups. If nil, a plain "Forbidden" text response is used.
+	ForbiddenHandler func(w http.ResponseWriter, r *http.Request)
 	// (optional) logger for messages, default is to std logger
 	Logger Logger
 }
@@ -228,7 +231,11 @@ func (svc *OIDC) Secure(next http.Handler, allowedGroups ...string) http.Handler
 func (svc *OIDC) restrictGroups(next http.Handler, allowedGroups []string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !Belongs(r, allowedGroups...) {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+			if svc.config.ForbiddenHandler != nil {
+				svc.config.ForbiddenHandler(w, r)
+			} else {
+				http.Error(w, "Forbidden", http.StatusForbidden)
+			}
 			return
 		}
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
## Description

Two fixes:

### 1. Group check ordering (bug fix)

The `Secure()` method placed the `allowedGroups` check as a wrapper around `secureHandler`, causing `Belongs()` to be called before the ID token is placed in the request context. Unauthenticated users received **403 Forbidden** instead of being redirected to the OIDC provider for login.

### 2. `ForbiddenHandler` config option (enhancement)

Adds a new optional `ForbiddenHandler func(w http.ResponseWriter, r *http.Request)` field to `Config`. When the group check denies access and this handler is set, it is called instead of the default plain `http.Error(w, "Forbidden", http.StatusForbidden)`. This allows users to render custom 403 pages (e.g. HTML error pages with branding).

Fixes #3
